### PR TITLE
Lots of README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 hodor
 =====
 
-Small utility to streamline dev process with Docker and Boot2Docker and Docker Machine ( Mac )
+Small utility to streamline dev process with Docker and Boot2Docker and Docker Machine (OS X)
 
 Blog posts with more info:
 
-* [http://distinctplace.com/infrastructure/2014/09/24/docker-vm-shortcomings-and-how-hodor-can-help/](http://distinctplace.com/infrastructure/2014/09/24/docker-vm-shortcomings-and-how-hodor-can-help/)
-* [http://distinctplace.com/infrastructure/2015/06/18/docker--hodor-to-simplify-app-setup/](Docker + Hodor for simple and reliable dev setup)
+* [Docker VM shortcomings and how hodor can help](http://distinctplace.com/infrastructure/2014/09/24/docker-vm-shortcomings-and-how-hodor-can-help/)
+* [Docker + Hodor for simple and reliable dev setup](http://distinctplace.com/infrastructure/2015/06/18/docker--hodor-to-simplify-app-setup/)
 
 features
 =====
-* same workflow for Linux and Mac ( Windows not supported yet )
-* volume sharing support for current project dir ( with unison and fswatch to keep host and VM in sync )
+* same workflow for Linux and OS X (Windows not supported yet)
+* volume sharing support for current project dir (with unison and fswatch to keep host and VM in sync)
 * exposed docker ports are automatically mapped to your host, it just works (VirtualBox only)
-* ssh key sharing support between host and containers ( ex: pull from github inside of the container without typing ssh key passwords )
+* ssh key sharing support between host and containers (ex: pull from github inside of the container without typing ssh key passwords)
 * containers orchestration with deps management, so we can start containers in particular order
-* separate containers list per project ( with .hodorfile )
+* separate containers list per project (with .hodorfile)
 
 Hodor Hodor Hodor
 
@@ -23,8 +23,11 @@ requirements
 =====
 * ruby >= 1.9.3
 * docker / boot2docker >= v1.1.2 / docker-machine
-* unison >= 2.40.102 ( for two-way sync on Macs, not required for Linux ) [Get it here](https://code.google.com/p/rudix-mountainlion/downloads/detail?name=unison-2.40.102-0.pkg)
-* fswatch >= 1.4.3.1 ( for automatic volumes sync on project file change on Macs, not required for Linux ) `brew install fswatch`. Make sure you fswatch version has -o ( --one-per-batch option ). If it's missing you need newer version.
+* unison = 2.40.x (for two-way sync on OS X, not required for Linux) 
+  - `brew install homebrew/versions/unison240`
+* fswatch >= 1.4.3.1 (for automatic volumes sync on project file change on OS X, not required for Linux) 
+  - `brew install fswatch`. 
+  - Make sure you `fswatch` version has -o option (--one-per-batch option). If it's missing, you will need the newer version.
 
 how to use
 =====
@@ -33,9 +36,12 @@ First you need to clone this repo, `chmod +x hodor` and copy hodor script to `/u
 
 In your project create file called `.hodorfile` (now processed through ERB) with following structure ( I'll explain options later, but everything should be pretty obvious from this example file:
 
-````
-host-manager: docker-machine (Optional. Default: boot2docker)
-host: default (Optional. VirtualBox vm name. Defaults: boot2docker-vm (boot2docker), default (docker-machine))
+```yaml
+# (Optional. Default: boot2docker)
+host-manager: docker-machine 
+# (Optional. VirtualBox vm name. 
+#    Defaults: boot2docker-vm (boot2docker), default (docker-machine))
+host: default
 
 containers:
   redis:
@@ -50,7 +56,9 @@ containers:
     image: gansbrest/fc_jetpack
     ports:
       - 49000:8880
-    links: ( **note:** if you use `net: host`, but still want to start conainers in particular order, you should use **depends** keyword with the list of continers instead )
+    # (**note:** if you use `net: host`, but still want to start conainers in 
+    # particular order, you should use **depends** keyword with the list of continers instead)
+    links:
       redis: redis
     environment:
       AWS_ACCESS_KEY_ID: <%= ENV['AWS_ACCESS_KEY_ID'] %>
@@ -75,16 +83,16 @@ tasks:
     sync_project_to: /data/slot-fc1
     cmd: "cd /data/slot-fc1 && ./simple_server"
     container: "jetpack"
-  default: run (if no task is given, the run task is executed)
-````
+  default: run #(if no task is given, the run task is executed)
+```
 
-Run Hodor with one of the tasks you specified while you are in project dir.
+Run `hodor` with one of the tasks you specified while you are in project dir.
 
 For example `hodor grunt build` - it will execute grunt build inside of the container and auto sync your host and VM after it's done!
 
 or
 
-`hodor run` - will run simple_server ( which is a wrapper for nodemon and some other stuff ) inside of the container. You will see nodemon output. Any files modified on host will automatically sync to container because of fswatch!
+`hodor run` - will run `simple_server` (which in the above example is a wrapper for nodemon and some other stuff) inside of the container. You will see nodemon output. Any files modified on host will automatically sync to container because of fswatch!
 
 This project is very raw. Report any issues, questions or suggestions.
 
@@ -112,10 +120,10 @@ SSHD in your containers: [http://jpetazzo.github.io/2014/06/23/docker-ssh-consid
 motivation
 =====
 
-Once I started working with Docker, my initial reaction was - "Hey, that's great, everything just works and I can even share my volumes and ports with host machine easily.." 
+Once I started working with Docker, my initial reaction was, "Hey, that's great, everything just works and I can even share my volumes and ports with host machine easily..." 
 
-Forgot to mention that I use Ubuntu as my desktop OS..  So I spent about a week to create multiple containers for our FastCompany stack ( node, redis etc ) and decided to convince our devs to integrate Docker as part of the new development process. Everything was suppose to be so much better. Boy, was I surprised..
+I forgot to mention that I use Ubuntu as my desktop OS....  So I spent about a week to create multiple containers for our FastCompany stack (node, redis etc) and decided to convince our devs to integrate Docker as part of the new development process. Everything was supposed to be so much better. Boy, was I surprised.
 
-Most of our dev team members use Macs. I always knew that. I think I was just misled by Docker docs, where they would say "It works everywhere, even on Windows! You just need this tiny VM to make it all happen". Well, let me make it short for you - Docker is PAIN in the b..t when you want to share volumes or ports, basically use it in VM.
+Most of our dev team members use Mac OS X. I always knew that. I think I was just misled by Docker docs, where they would say "It works everywhere, even on Windows! You just need this tiny VM to make it all happen." Well, let me make it short for you - Docker is PAIN in the b..t when you want to share volumes or ports, basically use it indirectly through any particular VM.
 
-I decided to create this tool called Hodor with one goal in mind - to create reliable helper/proxy, which allows to use Docker same way on Linux or Mac where volume sharing and ports are just working.
+I decided to create this tool called Hodor with one goal in mind - to create reliable helper/proxy, which allows to use of Docker same way on Linux or OS X, where volume sharing and ports are just working.

--- a/README.md
+++ b/README.md
@@ -10,14 +10,21 @@ Blog posts with more info:
 
 features
 =====
-* same workflow for Linux and OS X (Windows not supported yet)
+* same workflow for Linux and OS X 
 * volume sharing support for current project dir (with unison and fswatch to keep host and VM in sync)
 * exposed docker ports are automatically mapped to your host, it just works (VirtualBox only)
 * ssh key sharing support between host and containers (ex: pull from github inside of the container without typing ssh key passwords)
 * containers orchestration with deps management, so we can start containers in particular order
-* separate containers list per project (with .hodorfile)
+* separate containers list per project (with `.hodorfile`)
 
 Hodor Hodor Hodor
+
+unsupported
+=====
+* Windows OS
+* `docker-compose` toolchain
+
+PRs, suggestions, and contributions are welcomed.
 
 requirements
 =====

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ motivation
 
 Once I started working with Docker, my initial reaction was, "Hey, that's great, everything just works and I can even share my volumes and ports with host machine easily..." 
 
-I forgot to mention that I use Ubuntu as my desktop OS....  So I spent about a week to create multiple containers for our FastCompany stack (node, redis etc) and decided to convince our devs to integrate Docker as part of the new development process. Everything was supposed to be so much better. Boy, was I surprised.
+I forgot to mention that I use Ubuntu as my desktop OS... So I spent about a week to create multiple containers for our FastCompany stack (node, redis etc) and decided to convince our devs to integrate Docker as part of the new development process. Everything was supposed to be so much better. Boy, was I surprised.
 
 Most of our dev team members use Mac OS X. I always knew that. I think I was just misled by Docker docs, where they would say "It works everywhere, even on Windows! You just need this tiny VM to make it all happen." Well, let me make it short for you - Docker is PAIN in the b..t when you want to share volumes or ports, basically use it indirectly through any particular VM.
 


### PR DESCRIPTION
- Mac is the hardware name for Apple products running OS X, which the proper OS name. [Darwin](https://en.wikipedia.org/wiki/Darwin_%28operating_system%29), the core OS underneath OS X, is an [Apple-derived Mach-kernel plus various BSD components](https://en.wikipedia.org/wiki/History_of_OS_X), so I changed it to OS X where appropriate throughout.
- Consistency with parenthesis spacing in English prose (this) instead of ( that ).
- Fixed broken link markdown to author's blog posts.
- Changed instructions for OS X install via homebrew for unison pinned to 2.40, which is the (presently unpinned) version in the helper image of `gansbrest/fs-base`.
- Cleaned up sample `.hodorfile` with yaml markdown formatting.
- A little bit of grammar changes and fixes, although I tried to preserve the humor and ESL gentle mistakes, which are harmless, and, in my opinion, bring personality to this project, rather than making it read like all the other dull tech documentation.
- Added an **Unsupported** section
